### PR TITLE
Fix Memory Exhaust Issue

### DIFF
--- a/CPPWebFramework/cwf/httpreadrequest.cpp
+++ b/CPPWebFramework/cwf/httpreadrequest.cpp
@@ -138,7 +138,11 @@ bool HttpReadRequest::readBody(HttpParser &parser, Request &request, Response &r
     {
         if(socket->waitForReadyRead(10))
         {
-            content += socket->readAll();
+            if (content.size() > maxUploadFile) {
+                socket->readAll();
+            } else {
+                content += socket->readAll();
+            }
         }
 
         int spendTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count();
@@ -157,6 +161,7 @@ bool HttpReadRequest::readBody(HttpParser &parser, Request &request, Response &r
             break;
         }
     }
+
     if(content.size() > maxUploadFile)
     {
         request.getRequestDispatcher(STATUS::STATUS_403).forward(request, response);


### PR DESCRIPTION
Issue Discription:

with an incoming http requests the server will allocate memory as long as it recieves Data from the
incoming Connection even if a MaxUploadSize was defined. This behaviour will trigger a bad_alloc exception
then the server host runs out of memory and the server application will terminate.
A example would be you upload a 1GB File via a POST request to a server with 512 MB of Memory and no swap.

Issue Fix:

append incoming Data to the content buffer only as long as its size is smaller than maxUploadFile.
Otherwise throw away the Data and than return a Status 403 page

## Pull Request Checklist
Please check if your Pull Request fulfills the following requirements:

- [x] The commit message has a detailed description of the modifications
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (Please describe)
```

## What is the current behavior?


Issue Number: N/A


## What is the new behavior?


## Does this Pull Request introduce a breaking change?
```
[ ] Yes
[ ] No
```

## Other information
