### PR TITLE
修改了HttpParser::doParseHttpHeader解析header大小写未匹配的问题

### DIFF
--- a/CPPWebFramework/cwf/httpparser.cpp
+++ b/CPPWebFramework/cwf/httpparser.cpp
@@ -60,7 +60,6 @@ void HttpParser::doParseHttpHeader(QByteArray &httpMessage)
         if(line.isEmpty())
             continue;
         column = line.indexOf(':');
-
         QByteArray key = line.left(column).trimmed().toLower();
         headerField.insert(key, line.mid(column + 1).trimmed());
     }

--- a/CPPWebFramework/cwf/httpparser.cpp
+++ b/CPPWebFramework/cwf/httpparser.cpp
@@ -60,12 +60,14 @@ void HttpParser::doParseHttpHeader(QByteArray &httpMessage)
         if(line.isEmpty())
             continue;
         column = line.indexOf(':');
-        headerField.insert(line.left(column).trimmed(), line.mid(column + 1).trimmed());
+
+        QByteArray key = line.left(column).trimmed().toLower();
+        headerField.insert(key, line.mid(column + 1).trimmed());
     }
 
-    contentLenght = headerField.value(HTTP::CONTENT_LENGTH).toLongLong();
-    contentType   = headerField.value(HTTP::CONTENT_TYPE);
-    multiPart     = contentType.contains(HTTP::MULTIPART);
+    contentLenght = headerField.value(HTTP::CONTENT_LENGTH.toLower()).toLongLong();
+    contentType   = headerField.value(HTTP::CONTENT_TYPE.toLower());
+    multiPart     = contentType.contains(HTTP::MULTIPART.toLower());
     if(contentType.contains(HTTP::URLENCODED))
         doParseBody();
 


### PR DESCRIPTION
我是在使用了vite 的proxy 进行接口转发时发现的此类问题，应该是vite的代理将我原来的header全部转为小写了，例如将
Content-Length:256368 转为了content-length:256368
这样无法正确读取到body的总长度，因此body长度一旦超过tcp窗口的最大值，则无法正确运行httpreadrequest.cpp 中 HttpReadRequest::readBody的逻辑，导致我无法继续接收下一个tcp包的body数据，所以我的post body被截断了。